### PR TITLE
Update clic.adoc

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -192,9 +192,10 @@ The CLIC memory map supports up to 4096 total interrupt inputs.
 ----
 M-mode CLIC memory map
   Offset
-  ###   0x0008-0x07FF              reserved    ###
+  ###   0x0008-0x003F              reserved    ###
+  ###   0x00C0-0x07FF              reserved    ###
   ###   0x0800-0x0FFF              custom      ###
-
+  
   0x0000         1B          RW        cliccfg
   0x0004         4B          R         clicinfo
 


### PR DESCRIPTION
for issue #29 comment "The memory map table should have the reserved section reduced to omit the region allocated to interrupt triggers."  Created a 2nd reserved section so that clicinttrig is not within the reserved section.