### PR TITLE
Update clic.adoc-For hardware vectoring access exceptions, both {tval} and {epc} holds the faulting address. Spec update for issues #111 and #105

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -885,14 +885,9 @@ extensions are supported).
 For permissions-checking purposes, the memory access to retrieve the
 function pointer for vectoring is treated as a load with the privilege
 mode and interrupt level of the interrupt handler.  If there is an
-access exception on the table load, {epc} holds the faulting address.
-If this was a page fault, the table load can be resumed by returning
-with {epc} pointing to the table entry and the trap handler mode bit
-set.
+access exception on the table load, both {tval} and {epc} holds the faulting address.
 
-Instruction fetch at the handler address might cause misaligned or
-access exceptions, which are reported with {epc} containing the
-faulting instruction fetch address.
+NOTE: Horizontal traps (same privilege level) are unrecoverable. The interesting case is vertical traps, where a more privileged layer is handling page faults or other synchronous faults on vector table access. The regular code path in more privileged layer will want to use xtval to determine what bad virtual address to page in, but will not normally restore xtval when returning to faulting context (potentially after some time and other contexts have run) However, it will restore xepc (using x for more privileged mode here) before using xret on normal code path.  This is a rationale for why both {tval} and {epc} are written with the faulting address.
 
 In CLIC mode, synchronous exception traps always jump to NBASE.
 


### PR DESCRIPTION
For hardware vectoring access exceptions, both {tval} and {epc} holds the faulting address.  Spec update for issues #111 and #105 (option 2 reasoning)