### PR TITLE
pull for issue #197

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1047,10 +1047,30 @@ clears the low bit of the handler address, sets the PC to this handler
 address, then clears the {inhv} bit in {cause} of the handler privilege mode.
 
 ----
-if (xcause.inhv) //xcause here refers to the cause CSR of the previous privilege mode
-    pc := M[xepc] //xepc here refers to the current privilege mode
-else
-    pc := xepc
+match cur_privilege {
+  User => prev_inhv = ucause.INHV();
+  Supervisor => if sstatus.SPP() then {
+                  prev_inhv = scause.INHV(); 
+                } else {
+                  prev_inhv = ucause.INHV();
+                } 
+  Machine => match mstatus.MPP() {
+               User       => prev_inhv = ucause.INHV();
+               Supervisor => prev_inhv = scause.INHV();
+               Machine    => prev_inhv = mcause.INHV();
+             }
+
+match (ctl) {
+  CTL_URET => xepc = uepc;
+  CTL_SRET => xepc = sepc;
+  CTL_MRET => xepc = mepc;
+}
+
+if prev_inhv then {
+  set_next_pc(mem_read(xepc))
+} else {
+  set_next_pc(xepc)
+}
 ----
 NOTE: The inhv bit when set at xRET informs hardware to repeat the table load using the address in xEPC to obtain the address of the trap handler that is then written to the PC instead of directly writing xEPC to the PC.  One of the goals of this behavior is to avoid complicating the critical code paths for handling virtual memory in the more-privileged layer. The more-privileged layer does not have to distinguish CLIC vector table reads from other forms of data page fault and can handle them using exactly the same code.
 

--- a/clic.adoc
+++ b/clic.adoc
@@ -1047,6 +1047,7 @@ clears the low bit of the handler address, sets the PC to this handler
 address, then clears the {inhv} bit in {cause} of the handler privilege mode.
 
 ----
+/* get inhv value of previous privilege mode */
 match cur_privilege {
   User => prev_inhv = ucause.INHV();
   Supervisor => if sstatus.SPP() then {
@@ -1060,13 +1061,15 @@ match cur_privilege {
                Machine    => prev_inhv = mcause.INHV();
              }
 
-match (ctl) {
+/* is instruction URET, SRET or MRET */
+match (ctl) { 
   CTL_URET => xepc = uepc;
   CTL_SRET => xepc = sepc;
   CTL_MRET => xepc = mepc;
 }
 
 if prev_inhv then {
+  /* {epc} treated as an address instead of as an instruction */
   set_next_pc(mem_read(xepc) & ~1)
 } else {
   set_next_pc(xepc)

--- a/clic.adoc
+++ b/clic.adoc
@@ -1067,7 +1067,7 @@ match (ctl) {
 }
 
 if prev_inhv then {
-  set_next_pc(mem_read(xepc))
+  set_next_pc(mem_read(xepc) & ~1)
 } else {
   set_next_pc(xepc)
 }


### PR DESCRIPTION
tried to write pseudo SAIL code to make explicit which xinhv and which xepc is used on xRET.  This also shows xRET perform the same operation regardless of the mode in which they are executed.