### PR TITLE
CLIC parameter value ranges fix

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1347,7 +1347,7 @@ CLICANDBASIC   0-1                             Implements original basic mode al
 CLICPRIVMODES  1-3                             Number privilege modes: 1=M, 2=M/U,
                                                                        3=M/S/U
 CLICLEVELS     2-256                           Number of interrupt levels including 0
-NUM_INTERRUPT  4-4096                          Always has MSIP, MTIP, MEIP, CSIP
+NUM_INTERRUPT  2-4096                          Always has MSIP, MTIP
 CLICMAXID      12-4095                         Largest interrupt ID
 CLICINTCTLBITS 0-8                             Number of bits implemented in
                                                  clicintctl[i]
@@ -1356,7 +1356,7 @@ CLICCFGMBITS   0-ceil(lg2(CLICPRIVMODES))      Number of bits implemented for
 CLICCFGLBITS   0-ceil(lg2(CLICLEVELS))         Number of bits implemented for
                                                  cliccfg.nlbits
 CLICSELHVEC    0-1                             Selective hardware vectoring supported?
-CLICMTVECALIGN 6-13                            Number of hardwired-zero least
+CLICMTVECALIGN >= 6                            Number of hardwired-zero least
                                                  significant bits in mtvec address.
 CLICXNXTI      0-1                             Has xnxti CSR implemented?
 CLICXCSW       0-1                             Has xscratchcsw/xscratchcswl


### PR DESCRIPTION
Pull to fix parameter value ranges for NUM_INTERRUPT and CLICMTVECALIGN for issues #212 and #213