### PR TITLE
pull for proposed reformat of xcliccfg #96

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1,6 +1,7 @@
 :sectnums:
 :toc: left
 
+:cliccfg: pass:q[``**__x__**cliccfg``]
 :status: pass:q[``**__x__**status``]
 :edeleg: pass:q[``**__x__**edeleg``]
 :ideleg: pass:q[``**__x__**ideleg``]
@@ -341,7 +342,7 @@ M-mode CLIC memory map
   ###   0x00C0-0x07FF              reserved    ###
   ###   0x0800-0x0FFF              custom      ###
   
-  0x0000         1B          RW        cliccfg
+  0x0000         1B          RW        mcliccfg
   0x0004         4B          R         clicinfo
 
 
@@ -372,10 +373,11 @@ configured to be supervisor-accessible via the M-mode CLIC region.
 [source]
 ----
 Layout of Supervisor-mode CLIC regions
-0x000+4*i   1B/input    R or RW   clicintip[i]
-0x001+4*i   1B/input    RW        clicintie[i]
-0x002+4*i   1B/input    RW        clicintattr[i]
-0x003+4*i   1B/input    RW        clicintctl[i]
+0x0000         1B        RW        scliccfg
+0x1000+4*i   1B/input    R or RW   clicintip[i]
+0x1001+4*i   1B/input    RW        clicintie[i]
+0x1002+4*i   1B/input    RW        clicintattr[i]
+0x1003+4*i   1B/input    RW        clicintctl[i]
 ----
 
 User-mode CLIC regions only expose interrupts that have been
@@ -391,10 +393,11 @@ NOTE: Discovery mechanisms are still in development.
 [source]
 ----
 Layout of user-mode CLIC regions
-0x000+4*i   1B/input    R or RW   clicintip[i]
-0x001+4*i   1B/input    RW        clicintie[i]
-0x002+4*i   1B/input    RW        clicintattr[i]
-0x003+4*i   1B/input    RW        clicintctl[i]
+0x0000         1B        RW        ucliccfg
+0x1000+4*i   1B/input    R or RW   clicintip[i]
+0x1001+4*i   1B/input    RW        clicintie[i]
+0x1002+4*i   1B/input    RW        clicintattr[i]
+0x1003+4*i   1B/input    RW        clicintctl[i]
 ----
 
 A 32-bit write to {clicintctl,clicintattr,clicintie,clicintip} is legal. However, there is no specified order in which the effects of the individual byte updates take effect.
@@ -415,7 +418,7 @@ Likewise, in U-mode, any interrupt _i_ that is not accessible to U-mode appears 
 hard-wired zeros in `clicintip[__i__]`, `clicintie[__i__]`, `clicintattr[__i__]`, and
 `clicintctl[__i__]`.
 
-The privilege mode of an interrupt is controlled by both `cliccfg.nmbits` and `clicintattr[__i__].mode` as described in the Specifying Interrupt Privilege Mode section below.
+The privilege mode of an interrupt is controlled by both `mcliccfg.nmbits` and `clicintattr[__i__].mode` as described in the Specifying Interrupt Privilege Mode section below.
 
 It is not intended that the interconnect to the CLIC memory-mapped
 interrupt regions be required to carry the privilege mode of the
@@ -436,14 +439,14 @@ memory support.
 The CLIC specification does not dictate how CLIC memory-mapped registers are split between M/S/U regions as well as the layout of multiple harts as this is generally a platform issue and each platform needs to define a discovery mechanism to determine the memory map locations. Some considerations for platforms to consider are selecting regions that allow for efficient PMP and virtual memory configuration.
 For example, it may desired that the bases of each S/U-mode CLIC region is VM page (4k) aligned so they can be mapped through the TLBs.
 
-=== CLIC Configuration (`cliccfg`)
+=== CLIC Configuration ({cliccfg})
 
-The CLIC has a single memory-mapped 8-bit global configuration
-register, `cliccfg`, that defines how many privilege modes are supported,
+The CLIC has memory-mapped 8-bit global configuration
+registers, {cliccfg}, that define how many privilege modes are supported,
 how the `clicintctl[__i__]` registers are subdivided into level and
 priority fields, and whether selective hardware vectoring is supported.
 
-The `cliccfg` register has three WARL fields, a 2-bit `nmbits` field,
+The {cliccfg} register has three WARL fields, a 2-bit `nmbits` field,
 a 4-bit `nlbits` field, and a 1-bit `nvbits` field, plus a reserved
 bit WPRI-hardwired to zero in current spec.
 
@@ -456,7 +459,7 @@ not furnish these fields must hardwire them to zero.
 
 [source]
 ----
-  cliccfg register layout
+  mcliccfg register layout
 
   Bits    Field
   7       reserved (WPRI 0)
@@ -464,34 +467,51 @@ not furnish these fields must hardwire them to zero.
   4:1     nlbits[3:0]
     0     nvbits
 ----
+[source]
+----
+  scliccfg register layout
 
+  Bits    Field
+  7:5     reserved (WPRI 0)
+  4:1     nlbits[3:0]
+    0     nvbits
+----
+[source]
+----
+  ucliccfg register layout
+
+  Bits    Field
+  7:5     reserved (WPRI 0)
+  4:1     nlbits[3:0]
+    0     nvbits
+----
 Detailed explanation for each field are described in the following sections.
 
 ==== Specifying Interrupt Privilege Mode
 
-The 2-bit `cliccfg.nmbits` WARL field specifies how many bits are 
+The 2-bit `mcliccfg.nmbits` WARL field specifies how many bits are 
 physically implemented in `clicintattr[__i__].mode` to
-represent an input __i__'s privilege mode. Although `cliccfg.nmbits` field
+represent an input __i__'s privilege mode. Although `mcliccfg.nmbits` field
 is always 2-bit wide, the physically implemented bits in this field 
 can be fewer than two (depending how many interrupt privilege-modes are supported).
 
 For example, in M-mode-only systems, only M-mode exists so we do not
 need any extra bit to represent the supported privilege-modes. In this case,
 no physically implemented bits are needed in the `clicintattr.mode`
-and thus `cliccfg.nmbits` is 0 (i.e., `cliccfg.nmbits` can be hardwired to 0).
+and thus `mcliccfg.nmbits` is 0 (i.e., `mcliccfg.nmbits` can be hardwired to 0).
 
-In M/U-mode systems with N-extension user-level interrupts support, `cliccfg.nmbits` can be
-set to 0 or 1.  If `cliccfg.nmbits` = 0, then all interrupts are treated as
-M-mode interrupts.  If the `cliccfg.nmbits` = 1, then a value of 1 in
+In M/U-mode systems with N-extension user-level interrupts support, `mcliccfg.nmbits` can be
+set to 0 or 1.  If `mcliccfg.nmbits` = 0, then all interrupts are treated as
+M-mode interrupts.  If the `mcliccfg.nmbits` = 1, then a value of 1 in
 the most-significant bit (MSB) of a `clicintattr[__i__].mode` register
 indicates that interrupt intput is taken in M-mode,
 while a value of 0 indicates that interrupt is taken in U-mode.
 
-Similarly, in systems that support all M/S/U-mode interrupts, `cliccfg.nmbits`
+Similarly, in systems that support all M/S/U-mode interrupts, `mcliccfg.nmbits`
 can be set to 0, 1, or 2 bits to represent privilege-modes.
-`cliccfg.nmbits` = 0 indicates that all local interrupts are taken in
-M-mode.  `cliccfg.nmbits` = 1 indicates that the MSB selects between M-mode
-(1) and S-mode (0).  `cliccfg.nmbits` = 2 indicates that the two MSBs of
+`mcliccfg.nmbits` = 0 indicates that all local interrupts are taken in
+M-mode.  `mcliccfg.nmbits` = 1 indicates that the MSB selects between M-mode
+(1) and S-mode (0).  `mcliccfg.nmbits` = 2 indicates that the two MSBs of
 each `clicintattr[__i__].mode` register encode the interrupt's privilege
 mode using the same encoding as the `mstatus.mpp` field.
 
@@ -530,8 +550,8 @@ priv-modes nmbits clicintattr[i].mode  Interpretation
 
 ==== Specifying Interrupt Level
 
-The 4-bit `cliccfg.nlbits` WARL field indicates how many upper bits in
-`clicintctl[__i__]` are assigned to encode the interrupt level.
+The 4-bit {cliccfg}.`nlbits` WARL field indicates how many upper bits in
+`clicintctl[__i__]` are assigned to encode the interrupt level with a separate control per privilege level.
 
 Only 0 or 8 level bits are currently supported, with other values
 currently reserved.
@@ -543,8 +563,8 @@ level-bit settings but this is not currently being standardized.
 Although the interrupt level is an 8-bit unsigned integer, the number
 of bits actually assigned or implemented can be fewer than 8.
 As described above, the number of bits assigned is specified in
-`cliccfg.nlbits`. The number of bits actually implemented can be derived
-from `cliccfg.nlbits` and a fixed parameter `clicinfo.CLICINTCTLBITS`
+{cliccfg}.`nlbits`. The number of bits actually implemented can be derived
+from {cliccfg}.`nlbits` and a fixed parameter `clicinfo.CLICINTCTLBITS`
 (with value between 0 to 8) which specifies bits implemented for both
 interrupt level and priority.
 
@@ -573,7 +593,7 @@ for these cases.
 
 If `nlbits` = 0, then all interrupts are treated as level 255.
 
-Examples of `cliccfg` settings:
+Examples of {cliccfg}.`nlbits` settings:
 
  CLICINTCTLBITS nlbits clicintctl[i] interrupt levels
        0         2      ........     255
@@ -614,7 +634,7 @@ or 255.
 
 ==== Specifying Support for Selective Interrupt Hardware Vectoring
 
-The single-bit read-only `nvbits` field in `cliccfg` specifies whether
+The single-bit read-only `nvbits` field in {cliccfg} specifies whether
 the selective interrupt hardware vectoring feature is implemented or not.
 
 This selective hardware vectoring feature gives users the flexibility to
@@ -803,7 +823,7 @@ between 0 to 8. The implemented bits are kept left-justified
 in the most-significant bits of each 8-bit `clicintctl[__i__]`
 register, with the lower unimplemented bits treated as hardwired to 1.
 These control bits are interpreted as level and priority according to
-the setting in the CLIC Configuration register (`cliccfg.nlbits`).
+the setting in the CLIC Configuration register ({cliccfg}.`nlbits`).
 
 To select an interrupt to present to the core, the CLIC hardware
 combines the valid bits in `clicintattr.mode` and
@@ -975,7 +995,7 @@ specs.
  00001?                                        (CLIC mode)
              (non-vectored)
              pc := NBASE                                    if clicintattr[i].shv = 0
-                                                            || if cliccfg.nvbits = 0
+                                                            || if xcliccfg.nvbits = 0
                                                                (vector not supported)     
              (vectored)                                                    
              pc := M[TBASE + XLEN/8 * exccode)] & ~1        if clicintattr[i].shv = 1
@@ -994,7 +1014,7 @@ where the hart jumps to the
 trap handler address held in the upper XLEN-6 bits of
 {tvec} for all exceptions and interrupts in privilege mode
 `**__x__**`. Similarly, if the selective hardware
-vectoring feature is not implemented (`cliccfg.nvbits` is `0`),
+vectoring feature is not implemented ({cliccfg}.`nvbits` is `0`),
 all interrupts are non-vectored and behave the same.
 
 On the other hand, writing `1` to `clicintattr[__i__].shv`
@@ -1362,9 +1382,9 @@ CLICMAXID      12-4095                         Largest interrupt ID
 CLICINTCTLBITS 0-8                             Number of bits implemented in
                                                  clicintctl[i]
 CLICCFGMBITS   0-ceil(lg2(CLICPRIVMODES))      Number of bits implemented for
-                                                 cliccfg.nmbits
+                                                 mcliccfg.nmbits
 CLICCFGLBITS   0-ceil(lg2(CLICLEVELS))         Number of bits implemented for
-                                                 cliccfg.nlbits
+                                                 xcliccfg.nlbits
 CLICSELHVEC    0-1                             Selective hardware vectoring supported?
 CLICMTVECALIGN 6-13                            Number of hardwired-zero least
                                                  significant bits in mtvec address.
@@ -1491,7 +1511,7 @@ honor `clicintie[__i__]` and {intthresh}.
 * the interrupt priority reduction tree selects interrupt _i_ as the maximum across all pending-and-enabled interrupts and 
 * the interrupt _i_ level is not equal to 0.
 
-NOTE: Interrupt _i_ level is a function of CLICINTCTLBITS, `cliccfg.nlbits`, and `clicintctl[__i__]`.  If CLICINTCTLBITS is 8 and `cliccfg.nlbits` = 8, it is possible to set `clicintctl[__i__]` to 0.  Level 0 will behave as a locally disabled interrupt but can still mask lower-mode interrupts.  For example, if there is a non-zero level supervisor interrupt pending and a level-zero machine interrupt pending, the machine interrupt will be the global maximum across all pending-and-enabled interrupts but interrupt level 0 implies no interrupt. So programming `clicintctl[__i__]` to 0 should not be used to disable interrupts.  `clicintie[__i__]` should be used instead.
+NOTE: Interrupt _i_ level is a function of CLICINTCTLBITS, {cliccfg}.`nlbits`, and `clicintctl[__i__]`.  If CLICINTCTLBITS is 8 and {cliccfg}.`nlbits` = 8, it is possible to set `clicintctl[__i__]` to 0.  Level 0 will behave as a locally disabled interrupt but can still mask lower-mode interrupts.  For example, if there is a non-zero level supervisor interrupt pending and a level-zero machine interrupt pending, the machine interrupt will be the global maximum across all pending-and-enabled interrupts but interrupt level 0 implies no interrupt. So programming `clicintctl[__i__]` to 0 should not be used to disable interrupts.  `clicintie[__i__]` should be used instead.
 
 NOTE: {intthresh} only applies to the current privilege mode.  There is a proposal to add a new WFMI instruction ("wait for mode's interrupts") to the privilege specification. This instruction only has to wakeup for pending-and-enabled interrupts in the current mode, and is not required to wakeup for pending-and-enabled interrupts in lower privilege modes. Pending-enabled higher privilege-mode interrupts will interrupt/wakeup as usual. 
 
@@ -2052,7 +2072,7 @@ the C-ABI trampoline.
 
 Platforms may only implement non-vectored CLIC mode
 without selective hardware vectoring
-(`cliccfg.nvbits=0`), in which case, hardware vectoring can be emulated
+({cliccfg}.`nvbits`=0), in which case, hardware vectoring can be emulated
 by a single software trampoline present at `NBASE` using the separate
 vector table address in {tvt}.  There are several different software
 approaches possible, depending on system requirements and constraints,


### PR DESCRIPTION
separating cliccfg into mcliccfg,scliccfg,ucliccfg so each priv level can separately control nlbit behavior (level vs. priority).