### PR TITLE
xnxti pseudo-code clarification for issue #233

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1238,6 +1238,7 @@ selection and execution of interrupts using `{nxti}`.
 [source]
 --
  // Pseudo-code for csrrsi rd, mnxti, uimm[4:0] in M mode.
+ // clic.priv, clic.level, clic.id represent the highest-ranked interrupt currently present in the CLIC
  mstatus |= uimm[4:0]; // Performed regardless of interrupt readiness.
  if (clic.priv==M && clic.level > mcause.pil && clic.level > mintthresh.th
      && (cliccfg.nvbits==0 || clicintattr.shv==0) ) {


### PR DESCRIPTION
clarify definition of clic.priv, clic.level, clic.id in xnxti pseudo-code for issue #233.   Using same wording as seen in General Interrupt Overview section.