### PR TITLE
for issue #240 - change pseudocode for mscratchcsw to use mstatus.mpp

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -2310,7 +2310,7 @@ instructions set both `rs1` = `sp` and `rd` = `sp`.
   csrrw rd, mscratchcsw, rs1
 
   // Pseudocode operation.
-  if (mcause.mpp!=M-mode) then {
+  if (mstatus.mpp!=M-mode) then {
       t = rs1; rd = mscratch; mscratch = t;
   } else {
       rd = rs1; // mscratch unchanged.


### PR DESCRIPTION
For issue #240 
change pseudocode to use mstatus.mpp instead of mcause.mpp so mscratchcsw works in non-CLIC mode as well.