### PR TITLE
updating text to match table for issue #245

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -947,14 +947,14 @@ In systems that support both original basic and CLIC modes, the state bits in
 === New {tvec} CSR Mode for CLIC
 
 The new CLIC interrupt-handling mode is encoded as a new state in the
-existing {tvec} WARL register, where {tvec}.`mode` (the least-significant two bits) is
-`11`.  In this mode, the trap vector base address held in
+existing {tvec} WARL register, where {tvec}.`mode` (the least-significant six bits) is
+`00001?`.  In this mode, the trap vector base address held in
 {tvec} is constrained to be aligned on a 64-byte or larger
 power-of-two boundary.
 
 [source]
 ----
-  xtvec register layout
+ CLIC mode xtvec register layout
 
   Bits          Field 
   MXLEN-1:6     base (WARL)


### PR DESCRIPTION
Pull for issue #245 the table in section 5.4 lists xtvec.mode as xtvec bits 5:0, and clic mode is defined as 00001?.  Updating the above text to match.

Signed-off-by: Dan Smathers <dan.smathers@seagate.com>