### PR TITLE
STIP CLIC implementation note for issue #222

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -2597,6 +2597,9 @@ ID  Interrupt   Note
 17+ inputs      CLIC external inputs
 ----
 
+NOTE: In CLINT mode, as stated in the RISC-V privilege specification, each individual bit in CSR register {ip} may be writable or may be read-only. When bit i in {ip} is writable, a pending interrupt i can be cleared by writing 0 to this bit. STIP is writable in mip, and may be
+written by M-mode software to deliver timer interrupts to S-mode.  In CLIC mode, one possible equivalent implementation would be to hardwire the STIP input to 0 and M-mode software can deliver timer interrupts to S-mode by setting clicintattr[stip].trig to `00` (positive-edge-triggered) and writing clicintip[stip] to 1.    
+
 M-mode only or M/U mode interrupt map recommendation:
 (in M-only or M/U system without N extension)
 0: M-mode software interrupt


### PR DESCRIPTION
For issue #222 Write a note with an example of how m-mode software can deliver timer interrupts to s-mode by setting clicintattr.trig to positive-edge-triggered.

Signed-off-by: Dan Smathers <dan.smathers@seagate.com>