### PR TITLE
clic xcause clearing clarification

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1193,6 +1193,8 @@ switching to CLINT mode the new CLIC {cause} state fields
 {pp} and {pie}, appear as zero in the {cause} CSR but the corresponding
 state bits in the `mstatus` register are not cleared.
 
+Note: For now all privilege modes must run in either CLIC mode or all privilege modes must run in non-CLIC mode so switching to CLINT mode from CLIC mode causes {inhv} and {pil} in all privilege modes to be zeroed.
+
 In CLIC mode, when a trap is taken, {cause} has the CLIC format and the {cause} fields are updated ({inhv} is set by hardware at start of hardware vectoring, cleared at end of successful hardware vectoring, no change otherwise).
 On the other hand, when not in CLIC mode, {cause} has the CLINT mode format.
 


### PR DESCRIPTION
for issue #255  
clarify that since only all clic or all clint is supported, changing from clic to clint clears all xinhv and xpil fields to be cleared.

Signed-off-by: Dan Smathers <dan.smathers@seagate.com>