### PR TITLE
for issue #295, include mention of xintthresh clearing and DRET

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1003,6 +1003,11 @@ privileged than `x` also sets {intthresh} = 0.  This prevents a higher
 privilege mode from having a non-zero threshold while a lower
 privilege mode is running.
 
+Likewise, if the RISC-V debug specification is implemented and 
+the hart is currently running at some privilege mode `x`, a DRET 
+instruction that changes the privilege mode to a mode less privileged 
+than `x` also sets {intthresh} = 0.
+
 NOTE: The anticipated use of threshold is to provide critical sections
 within code running at one privilege level, not to selectively mask
 interrupts before running lower-privilege code.  If desired,


### PR DESCRIPTION
pull #310 added text that clears xintthresh going to lower priv with MRET, SRET.  Adding equivalent text for when debug spec DRET goes to lower priv.