### PR TITLE
add CSRRW option for xnxti CSR

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -898,7 +898,7 @@ interrupt for the same privilege mode when it has greater level than
 the saved interrupt context (held in {cause}`.pil`) and greater level
 than the interrupt threshold of the corresponding privilege mode, without incurring
 the full cost of an interrupt pipeline flush and context save/restore.
-The {nxti} CSR is designed to be accessed using CSRRSI/CSRRCI
+The {nxti} CSR is designed to be accessed using CSRRSI/CSRRCI/CSRRW
 instructions, where the value read is a pointer to an entry in the
 trap handler table and the write back updates the interrupt-enable
 status. In addition, writes to the {nxti} have side-effects that
@@ -908,7 +908,7 @@ NOTE: This is different than a regular CSR instruction as the value
 returned is different from the value used in the read-modify-write
 operation.
  
-These CSRs are only designed to be used with the CSRR (CSRRS rd,csr,x0), CSRRSI, and CSRRCI instructions. Accessing the {nxti} CSR using any other CSR instruction form (CSRRW/CSRRS,rs1!=x0/CSRRC/CSRRWI) is reserved.
+These CSRs are only designed to be used with the CSRR (CSRRS rd,csr,x0), CSRRSI, CSRRCI, CSRRW instructions. Accessing the {nxti} CSR using any other CSR instruction form (CSRRS,rs1!=x0/CSRRC/CSRRWI) is reserved.
 Note: Use of xnxti with CSRRSI with non-zero uimm values for bits 0, 2, and 4 are reserved for future use.
 
 A read of the {nxti} CSR using CSRR returns either zero, indicating there is no
@@ -916,9 +916,10 @@ suitable interrupt to service or that the system is not in a CLIC mode, or retur
 address of the entry in the trap handler table for software trap
 vectoring.
 
-If the CSR instruction that accesses {nxti} includes a write, the
-{status} CSR is the one used for the read-modify-write portion of the
-operation, while the {cause} register's `exccode` field and the
+If the CSR instruction that accesses {nxti} includes a write, 
+bits [4:0] of {status} CSR and bits 23:16 of {cause} CSR are used 
+for the read-modify-write portion of the
+operation bits, while the {cause} register's `exccode` field and the
 {intstatus} register's {il} field can also be updated with the new interrupt id and level.
 If the interrupt is edge-triggered, then the pending bit is also zeroed.
 
@@ -967,6 +968,30 @@ selection and execution of interrupts using `{nxti}`.
  // When a different privileges xnxti CSR is accessed then clic.priv is compared with
  // the corresponding privilege and xstatus, xintstatus.xil, xcause.exccode are the 
  // corresponding privileges CSRs.
+----
+
+[source]
+----
+ // Pseudo-code for csrrw rd, mnxti, rs1 in M mode.
+ // clic.priv, clic.level, clic.id represent the highest-ranked interrupt currently present in the CLIC
+ mstatus[4:0] = rs1[4:0]; // Performed regardless of interrupt readiness.
+ mcause[23:16] = rs1[23:16]; // updates mcause.pil so rs1[23:16] is effectively used instead of mcause.pil to check if there is an available interrupt
+ if (clic.priv==M && clic.level > mcause.pil && clic.level > mintthresh.th) {
+   // There is an available interrupt.
+   if (rd != x0) {  // Side-effects should occur.
+     // Commit to servicing the available interrupt.
+     mintstatus.mil = clic.level; // Update hart's interrupt level.
+     mcause.exccode = clic.id;   // Update interrupt id in mcause.
+     mcause.interrupt = 1;       // Set interrupt bit in mcause.
+     if (clicintattr[clic.id][1] == 1) { // If edge interrupt,
+       clicintip[clic.id] = 0;           // clear edge interrupt
+     }
+   }
+   rd = TBASE + XLEN/8 * clic.id; // Return pointer to trap handler entry.
+ } else {
+   // No interrupt or in non-CLIC mode.
+   rd = 0;
+ }
 ----
 
 NOTE: Vertical interrupts to different privilege modes will be taken


### PR DESCRIPTION
for issue #308, allows setting mcause.mpil (used by xnxti to filter interrupts) as atomic with xnxti write.