### PR TITLE
adding Smstateen extension text to s-mode clic CSRs

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1369,6 +1369,12 @@ additions for CLIC mode described in the following sections.
 
 ----
 
+==== State Enable
+If the Smstateen extension is implemented, then bit X in mstateen0 is
+implemented. If bit X of a controlling stateen0 CSR is zero, then access to the 
+new CSRs (stvt, snxti, sintstatus, sintthresh, sscratchcsw, sscratchcswl)
+by a lower privilege level results in appearing hardwired to zero on reads and writes are ignored and will not trap (i.e., no access faults).
+
 ==== ssclic Changes to {cause} CSRs
 
 [source]


### PR DESCRIPTION
For issue #345, add State enable text similar to that found in Zcmt spec for JVT CSR (although JVT CSR access causes an illegal instruction trap instead of ignoring writes and returning 0 on reads.