### PR TITLE
Clarify/Fix Smclic Ssclic Suclic memory map reserved areas

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -404,11 +404,11 @@ The CLIC memory map supports up to 4096 total interrupt inputs.
 ----
 M-mode CLIC memory map
   Offset
-  ###   0x0008-0x003F              reserved    ###
+  ###   0x0004-0x003F              reserved    ###
   ###   0x00C0-0x07FF              reserved    ###
   ###   0x0800-0x0FFF              custom      ###
   
-  0x0000         1B          RW        reserved for smclicconfig extension 
+  0x0000         4B          RW        reserved for smclicconfig extension 
 
   0x0040         4B          RW        clicinttrig[0]
   0x0044         4B          RW        clicinttrig[1]
@@ -1314,8 +1314,11 @@ configured to be supervisor-accessible via the M-mode CLIC region.
 
 [source]
 ----
+Offset
+  ###   0x0004-0x07FF              reserved    ###
+  ###   0x0800-0x0FFF              custom      ###
 Layout of Supervisor-mode CLIC regions
-0x0000       1B          RW        reserved for smclicconfig extension 
+0x0000       4B          RW        reserved for smclicconfig extension 
 0x1000+4*i   1B/input    R or RW   clicintip[i]
 0x1001+4*i   1B/input    RW        clicintie[i]
 0x1002+4*i   1B/input    RW        clicintattr[i]
@@ -1452,8 +1455,11 @@ configured to be user-accessible via the higher privilege mode CLIC regions.
 
 [source]
 ----
+Offset
+  ###   0x0004-0x07FF              reserved    ###
+  ###   0x0800-0x0FFF              custom      ###
 Layout of user-mode CLIC regions
-0x0000       1B          RW        reserved for smclicconfig extension 
+0x0000       4B          RW        reserved for smclicconfig extension 
 0x1000+4*i   1B/input    R or RW   clicintip[i]
 0x1001+4*i   1B/input    RW        clicintie[i]
 0x1002+4*i   1B/input    RW        clicintattr[i]


### PR DESCRIPTION
memory map clarification for issue #351
smclicconfig was changed from 1B to using 4B so memory map reserved areas need to be updated.  tried to make Ssclic and Suclic match Smclic memory map documentation.