### PR TITLE
cleanup NUM_INTERRUPT in parameters section

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1928,8 +1928,8 @@ When NVBITS is 1, smclicshv extension is implemented.
 
 === CLICINFO Parameters
 
-The NUM_INTERRUPT 13-bit parameter specifies the actual number of maximum interrupt
-inputs supported in this implementation.
+The NUM_INTERRUPT 13-bit parameter from 2-4096 that specifies the actual number of maximum interrupt
+inputs supported in this implementation. MSIP, MTIP are always included.
 
 The VERSION 8-bit parameter specifies the implementation version of CLIC. The upper
 4-bit specifies the architecture version, and the lower 4-bit specifies
@@ -1953,7 +1953,6 @@ CLICANDBASIC   0-1                             Implements CLINT mode also?
 CLICPRIVMODES  1-3                             Number privilege modes: 1=M, 2=M/U,
                                                                        3=M/S/U
 CLICLEVELS     2-256                           Number of interrupt levels including 0
-NUM_INTERRUPT  2-4096                          Always has MSIP, MTIP
 CLICMAXID      12-4095                         Largest interrupt ID
 
 INTTHRESHBITS  1-8                             Number of bits implemented in {intthresh}.th


### PR DESCRIPTION
for issue #307, combined two descriptions of NUM_INTERRUPT in the parameters section to a single description.