### PR TITLE
add xcause.xpil fields to mandatory reset state

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1204,7 +1204,7 @@ out of reset.
 
 ==== CLIC mandatory reset state
 
-{intstatus}.{il} fields reset to 0.  Interrupt level 0 corresponds to regular
+{intstatus}.{il} and {cause}.{pil} fields reset to 0.  Interrupt level 0 corresponds to regular
 execution outside of an interrupt handler.
 
 The reset behavior of other fields is platform-specific.


### PR DESCRIPTION
Since switching from CLINT to CLIC modes already requires xpil in all privilege modes to be zeroed, it follows that they should also just be reset if starting in CLIC mode.