### PR TITLE
For issue #374 - remove special xnxti CLINT mode behavior statement

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1013,10 +1013,6 @@ NOTE: Vertical interrupts to different privilege modes will be taken
 preemptively by the hardware, so {nxti} effectively only ever handles
 the next interrupt in the same privilege mode.
 
-In CLINT mode, reads of {nxti} return 0, updates to {status} proceed
-as in CLIC mode, but updates to {intstatus} and {cause} do not take
-effect.
-
 ==== New Interrupt Status ({intstatus}) CSRs
 
 A new M-mode CSR, `mintstatus`, holds the active interrupt level for


### PR DESCRIPTION
For issue #374, change nxti behavior in CLINT mode to reflect what is stated at the start of the CLIC CSR section:

Unless explicitly specified differently below, when not in CLIC mode, behavior of CLIC-only CSRs should be same as if CLIC was not implemented, so should be treated as a "reserved" operation.