### PR TITLE
Fix general interrupt overview table ie description

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1258,11 +1258,11 @@ privilege mode.
 
 The overall behavior is summarized in the following table: the Current
 `p/ie/il` fields represent the current privilege mode `P` (not
-software visible), interrupt enable `ie` = 
-({status}.{ie} & `clicintie[__i__]`)  and interrupt
+software visible), new privilege mode global interrupt enable `ie` and interrupt
 level `L` = max({intstatus}.{il}, {intthresh}.`th`);
 the CLIC `priv`,`level`, and `id` fields
-represent the highest-ranked interrupt currently present in the CLIC
+represent the highest-ranked pending and enabled interrupt 
+(`clicintip[__i__]` & `clicintie[__i__]` == 1) currently present in the CLIC
 with `nP` representing the new privilege mode, `nL` representing the
 new interrupt level, and `id` representing the interrupt's id;
 Current' shows the `p/ie/il` context in the handler's privilege mode;

--- a/clic.adoc
+++ b/clic.adoc
@@ -1281,7 +1281,8 @@ context fields in {cause} and {epc}.
  P  1  L  | nP=P   0<nL<=L  ?  |->    - -  -   -   -     -  -  -  -   # Interrupt ignored
  P  1  L  | nP=P   L<nL    id  |->    P 0  nL  V   id    P  L  1  pc  # Horizontal interrupt taken
  P  ?  ?  | nP>P     0      ?  |->    - -  -   -   -     -  -  -  -   # No interrupt
- P  e  L  | nP>P   0<nL    id  |->   nP 0  nL  V   id    P  L  e  pc  # Vertical interrupt taken
+ P  0  L  | nP>P   0<nL    id  |->   nP 0  nL  V   id    P  L  0  pc  # Vertical interrupt taken
+ P  1  L  | nP>P   0<nL    id  |->   nP 0  nL  V   id    P  L  1  pc  # Vertical interrupt taken
 ----
 
 ==== Critical Sections in Interrupt Handlers


### PR DESCRIPTION
ie represents the new global interrupt enable mstatus.xie.  Clarify that the highest ranked interrupt must have clicintip[i] and clicintie[i] == 1.