### PR TITLE
mnxti pseudo code clarification when rs1 == x0

### DIFF
--- a/clic.adoc
+++ b/clic.adoc
@@ -1033,7 +1033,7 @@ selection and execution of interrupts using `{nxti}`.
 ----
 [source]
 ----
- // Pseudo-code for csrrs rd, mnxti, rs1 in M mode.
+ // Pseudo-code for csrrs rd, mnxti, rs1, rs1 != x0 in M mode.
  // clic.priv, clic.level, clic.id represent the highest-ranked interrupt currently present in the CLIC
    if (rs1 != x0)
    {


### PR DESCRIPTION
it is confusing when doing csrr  (rs1 == x0) whether clic.level should be compared against mcause.mpil or whether it should be compared to 0  (rs1[23:16]).  I think the intent is that csr reads are compared to mcause.mpil.