### PR TITLE
414 move register layout definitions into wavedrom

### DIFF
--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -555,7 +555,7 @@ only certain mode/trigger/shv types.
   0       reserved for smclicshv extension (WARL 0)
 ----
 .clicintattr[i] register layout
-include::images/wavedrom/clicintattr.edn[]
+include::images/wavedrom/clicintattri.edn[]
 
 The 2-bit `trig` WARL field specifies the trigger type and polarity for each
 interrupt input. Bit 1, `trig[0]`, is defined as "edge-triggered"
@@ -653,6 +653,7 @@ following layout:
 
 ----
 
+.clicinttrig register layout
 include::images/wavedrom/clicinttrig.edn[]
 
 The `interrupt_number` field selects which number of interrupt input
@@ -826,6 +827,7 @@ larger power-of-two boundary.
   1:0           mode (WARL)
 ----
 
+.CLIC mode xtvec register layout
 include::images/wavedrom/xtvec.edn[]
 
 NOTE: Systems implementing both CLIC and CLINT mode may, but are not
@@ -1580,6 +1582,9 @@ This is an 8-bit WARL read-write register to specify various attributes for each
   2:1     trig
   0       shv
 ----
+
+.clicintattr register layout
+include::images/wavedrom/clicintattr.edn[]
 
 The 1-bit `shv` field is used for Selective Hardware Vectoring.
 If `shv` is 0, it assigns this interrupt to be software vectored and thus it jumps

--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -826,6 +826,8 @@ larger power-of-two boundary.
   1:0           mode (WARL)
 ----
 
+include::images/wavedrom/xtvec.edn[]
+
 NOTE: Systems implementing both CLIC and CLINT mode may, but are not
 required to, limit alignment of `mtvec` to 64-byte boundaries in both
 modes.

--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -554,7 +554,7 @@ only certain mode/trigger/shv types.
   2:1     trig
   0       reserved for smclicshv extension (WARL 0)
 ----
-
+.clicintattr[i] register layout
 include::images/wavedrom/clicintattr.edn[]
 
 The 2-bit `trig` WARL field specifies the trigger type and polarity for each
@@ -652,6 +652,8 @@ following layout:
   12:0    interrupt_number
 
 ----
+
+include::images/wavedrom/clicinttrig.edn[]
 
 The `interrupt_number` field selects which number of interrupt input
 is used as the source for this interrupt trigger.

--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -555,6 +555,8 @@ only certain mode/trigger/shv types.
   0       reserved for smclicshv extension (WARL 0)
 ----
 
+include::images/wavedrom/clicintattr.edn[]
+
 The 2-bit `trig` WARL field specifies the trigger type and polarity for each
 interrupt input. Bit 1, `trig[0]`, is defined as "edge-triggered"
 (0: level-triggered, 1: edge-triggered); while bit 2, `trig[1]`, is defined

--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -135,6 +135,7 @@ Creative Commons Attribution 4.0 International License.
 [source]
 ----
 Date        Description
+11/11/2024  issue #414 - Move register layout definitions into wavedrom
 09/10/2024  issue #411 - Clarify that smclicshv ignores 1 or 2 LSBs of vector table entry (depending on IALIGN)
 09/10/2024  pull  #404 - First round of reorganization of the document to move SW information to Appendix
 08/30/2024  issue #401 - First round of changes to improve clarity of document. Removed mention of U-mode interrupts.

--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -544,16 +544,6 @@ This is an 8-bit WARL read-write register to specify various attributes for each
 NOTE: This register is defined as WARL as some implementations may want to hardwire to fixed values
 only certain mode/trigger/shv types.
 
-[source]
-----
-  clicintattr[i] register layout
-
-  Bits    Field
-  7:6     mode
-  5:3     reserved (WPRI 0)
-  2:1     trig
-  0       reserved for smclicshv extension (WARL 0)
-----
 .clicintattr[i] register layout
 include::images/wavedrom/clicintattri.edn[]
 
@@ -640,18 +630,6 @@ This logic is intended to be used with tmexttrigger.intctl as described in the R
 
 Each interrupt trigger is a 32-bit WARL register with the
 following layout:
-
-[source]
-----
-  clicinttrig register layout
-
-  Bits    Field
-  31      interrupt_trap_enable
-  30      nxti_enable
-  29:13   reserved (WARL 0)
-  12:0    interrupt_number
-
-----
 
 .clicinttrig register layout
 include::images/wavedrom/clicinttrig.edn[]
@@ -816,16 +794,6 @@ are reserved for future use.  The trap vector base address is
 specified as the upper XLEN-6 bits of {tvec} (`base`) with six
 lower zero bits appended, which constrains alignment on a 64-byte or
 larger power-of-two boundary.
-
-[source]
-----
- CLIC mode xtvec register layout
-
-  Bits          Field
-  XLEN-1:6      base (WARL)
-  5:2           submode (WARL)
-  1:0           mode (WARL)
-----
 
 .CLIC mode xtvec register layout
 include::images/wavedrom/xtvec.edn[]
@@ -1572,17 +1540,6 @@ of the appropriate access to the {nxti} CSR (see that CSR's description for deta
 
 This is an 8-bit WARL read-write register to specify various attributes for each interrupt.
 
-[source]
-----
-  clicintattr register layout
-
-  Bits    Field
-  7:6     mode
-  5:3     reserved (WPRI 0)
-  2:1     trig
-  0       shv
-----
-
 .clicintattr register layout
 include::images/wavedrom/clicintattr.edn[]
 
@@ -1971,30 +1928,9 @@ the values held in these fields when writing values to other fields of
 the same register. For forward compatibility, implementations that do
 not furnish these fields must hardwire them to zero.
 
-[source]
-----
-  mcliccfg register layout
-
-  Bits    Field
-  31:20   reserved (WPRI 0)
-  19:16   snlbits[3:0] if ssclic is supported, else reserved (WPRI 0)
-  15:6    reserved (WPRI 0)
-   5:4    nmbits[1:0]
-   3:0    mnlbits[3:0]
-----
-
 .mcliccfg register layout
 include::images/wavedrom/mcliccfg.edn[]
 
-[source]
-----
-  scliccfg register layout - dependent on ssclic extension
-
-  Bits    Field
-  31:20   reserved (WPRI 0)
-  19:16   snlbits[3:0] if ssclic is supported, else reserved (WPRI 0)
-  15:0    reserved (WPRI 0)
-----
 .scliccfg register layout
 include::images/wavedrom/scliccfg.edn[]
 

--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -1983,6 +1983,9 @@ not furnish these fields must hardwire them to zero.
    3:0    mnlbits[3:0]
 ----
 
+.mcliccfg register layout
+include::images/wavedrom/mcliccfg.edn[]
+
 [source]
 ----
   scliccfg register layout - dependent on ssclic extension
@@ -1992,6 +1995,8 @@ not furnish these fields must hardwire them to zero.
   19:16   snlbits[3:0] if ssclic is supported, else reserved (WPRI 0)
   15:0    reserved (WPRI 0)
 ----
+.scliccfg register layout
+include::images/wavedrom/scliccfg.edn[]
 
 scliccfg is a subset of the mcliccfg register.
 

--- a/src/images/wavedrom/clicintattr.edn
+++ b/src/images/wavedrom/clicintattr.edn
@@ -1,0 +1,10 @@
+[wavedrom, ,svg]
+....
+{reg: [
+  {bits: 1, name: 'shv' },
+  {bits: 2, name: 'trig' },
+  {bits: 3, name: 'WPRI(0)' },
+  {bits: 2, name: 'trigshv' },
+  {bits: 2, name: 'mode' },
+]}
+....

--- a/src/images/wavedrom/clicintattr.edn
+++ b/src/images/wavedrom/clicintattr.edn
@@ -1,0 +1,9 @@
+[wavedrom, ,svg]
+....
+{reg: [
+  {bits: 1, name: 'WARL(0)' },
+  {bits: 2, name: 'trig' },
+  {bits: 3, name: 'WPRI(0)' },
+  {bits: 2, name: 'mode' },
+  ]}
+....

--- a/src/images/wavedrom/clicintattr.edn
+++ b/src/images/wavedrom/clicintattr.edn
@@ -1,9 +1,0 @@
-[wavedrom, ,svg]
-....
-{reg: [
-  {bits: 1, name: 'WARL(0)' },
-  {bits: 2, name: 'trig' },
-  {bits: 3, name: 'WPRI(0)' },
-  {bits: 2, name: 'mode' },
-  ]}
-....

--- a/src/images/wavedrom/clicintattri.edn
+++ b/src/images/wavedrom/clicintattri.edn
@@ -1,0 +1,10 @@
+[wavedrom, ,svg]
+....
+{reg: [
+  {bits: 1, name: 'shv' },
+  {bits: 2, name: 'trig' },
+  {bits: 3, name: 'WPRI(0)' },
+  {bits: 2, name: 'trigshv' },
+  {bits: 2, name: 'mode' },
+]}
+....

--- a/src/images/wavedrom/clicintattri.edn
+++ b/src/images/wavedrom/clicintattri.edn
@@ -1,10 +1,9 @@
 [wavedrom, ,svg]
 ....
 {reg: [
-  {bits: 1, name: 'shv' },
+  {bits: 1, name: 'WARL(0)' },
   {bits: 2, name: 'trig' },
   {bits: 3, name: 'WPRI(0)' },
-  {bits: 2, name: 'trigshv' },
   {bits: 2, name: 'mode' },
-]}
+  ]}
 ....

--- a/src/images/wavedrom/clicinttrig.edn
+++ b/src/images/wavedrom/clicinttrig.edn
@@ -1,0 +1,13 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
+(def row-height 45)
+(def row-header-fn nil)
+(def boxes-per-row 32)
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "12" "13" "" "" "" "" "" "" "" "29" "" "" "30" "" "" "" "" "" "" "31" "" "" "" ""])})
+
+(draw-box "interrupt_trap_enable" {:span 9})
+(draw-box "nxti_enable" {:span 5})
+(draw-box "reserved (WARL 0)" {:span 9})
+(draw-box "interrupt_number" {:span 9})
+----

--- a/src/images/wavedrom/mcliccfg.edn
+++ b/src/images/wavedrom/mcliccfg.edn
@@ -1,0 +1,14 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
+(def row-height 45)
+(def row-header-fn nil)
+(def boxes-per-row 32)
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "3" "4" "" "5" "6" "" "" "" "15" "16" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "19" "20" "" "" "" "31"])})
+
+(draw-box "reserved (WPRI 0)" {:span 5})
+(draw-box "snlbits[3:0] if ssclic is supported, else reserved (WPRI 0)" {:span 16})
+(draw-box "reserved (WPRI 0)" {:span 5})
+(draw-box "nmbits[1:0]" {:span 3})
+(draw-box "mnlbits[3:0]" {:span 3})
+----

--- a/src/images/wavedrom/scliccfg.edn
+++ b/src/images/wavedrom/scliccfg.edn
@@ -1,0 +1,12 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
+(def row-height 45)
+(def row-header-fn nil)
+(def boxes-per-row 32)
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "15" "16" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "19" "20" "" "" "" "" "" "" "31"])})
+
+(draw-box "reserved (WPRI 0)" {:span 8})
+(draw-box "snlbits[3:0] if ssclic is supported, else reserved (WPRI 0)" {:span 16})
+(draw-box "reserved (WPRI 0)" {:span 8})
+----

--- a/src/images/wavedrom/xtvec.edn
+++ b/src/images/wavedrom/xtvec.edn
@@ -1,0 +1,12 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback"}])
+(def row-height 45)
+(def row-header-fn nil)
+(def boxes-per-row 32)
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "5" "6" "" "" "" "" "" "" "XLEN-1"])})
+
+(draw-box "mode (WARL)" {:span 8})
+(draw-box "submode (WARL)" {:span 16})
+(draw-box "base (WARL)" {:span 8})
+----


### PR DESCRIPTION
I've added several register definitions as diagrams and removed the text based descriptions.  If additional register diagrams are required, please open a new issue and assign to me.