### PR TITLE
remove reference to wfmi

### DIFF
--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -751,7 +751,7 @@ honor `clicintie[__i__]` and {intthresh}.
 * has a lower privilege mode than the current privilege mode and
 * the interrupt priority reduction tree selects interrupt _i_ as the maximum across all pending-and-enabled interrupts and
 
-NOTE: {intthresh} only applies to the current privilege mode.  There is a proposal to add a new WFMI instruction ("wait for mode's interrupts") to the privilege specification. This instruction only has to wakeup for pending-and-enabled interrupts in the current mode, and is not required to wakeup for pending-and-enabled interrupts in lower privilege modes. Pending-enabled higher privilege-mode interrupts will interrupt/wakeup as usual.
+NOTE: {intthresh} only applies to the current privilege mode.
 
 ==== Synchronous Exception Handling
 


### PR DESCRIPTION
for issue #471.  WFMI proposal was created but never got past draft form.  removing from clic spec.