### PR TITLE
Removing version number from files in the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DOCS := \
 	clic.adoc
 
 DATE ?= $(shell date +%Y-%m-%d)
-VERSION ?= v0.9
+VERSION ?= dev
 REVMARK ?= Draft
 DOCKER_IMG := riscvintl/riscv-docs-base-container-image:latest
 ifneq ($(SKIP_DOCKER),true)

--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -12,8 +12,8 @@
 include::../docs-resources/global-config.adoc[]
 :docgroup: RISC-V Task Group
 :description: RISC-V Example Specification Document (Zexmpl)
-:revdate: 3/2025
-:revnumber: 0.9
+:revdate: current
+:revnumber: dev
 :revremark: This document is under development. Expect potential changes. Visit http://riscv.org/spec-state for further details.
 :revinfo:
 :preface-title: Preamble


### PR DESCRIPTION
- version number is set externally when building the document, which overrides the settings in the files