### PR TITLE
recommend unimplemented LSBs of clicintlvl be 1.

### DIFF
--- a/src/clic.adoc
+++ b/src/clic.adoc
@@ -516,7 +516,11 @@ interrupt level of zero.
 NOTE: Implementations may choose to make CLIC parameters configurable prior to operation.
 
 A parameterized number of upper bits in
-`clicintlvl[__i__]` are assigned to encode the interrupt level.
+`clicintlvl[__i__]` are assigned to encode the interrupt level. 
+
+NOTE: Platforms and Profiles may assign additional requirements on the number of levels and priority each privilege level must support.  
+Implementations may wish to build flexible implementations to support these future requirements.  
+At a minimum, it is recommended to assign 1 to unimplemented LSBs of `clicintlvl[__i__]`. 
 
 ==== Indirect Access to interrupt level CSRs - `clicintlvl[__i__]`
 


### PR DESCRIPTION
For issue #489, leave requirements of the number of levels to future platforms and profiles but add recommendation of LSBs of clicintlvl be 1 to be compatible with previous CLIC recommendations and to possibly make HW compatible with future platforms/profiles.