### PR TITLE
Update clicintattr.edn for issue #527

### DIFF
--- a/src/images/wavedrom/clicintattr.edn
+++ b/src/images/wavedrom/clicintattr.edn
@@ -3,8 +3,6 @@
 {reg: [
   {bits: 1, name: 'shv' },
   {bits: 2, name: 'trig' },
-  {bits: 3, name: 'WPRI(0)' },
-  {bits: 2, name: 'trigshv' },
-  {bits: 2, name: 'mode' },
+  {bits: 5, name: 'WPRI(0)' },
 ]}
 ....

--- a/src/images/wavedrom/clicintattri.edn
+++ b/src/images/wavedrom/clicintattri.edn
@@ -3,7 +3,6 @@
 {reg: [
   {bits: 1, name: 'WARL(0)' },
   {bits: 2, name: 'trig' },
-  {bits: 3, name: 'WPRI(0)' },
-  {bits: 2, name: 'mode' },
+  {bits: 5, name: 'WPRI(0)' },
   ]}
 ....


### PR DESCRIPTION
Closes issue #527
remove mode from clicintattr (now using ideleg) and removing trigshv because it isn't defined anywhere in the spec.