### PR TITLE
Smip: Changed push/pop to only be applicable to interrupts

### DIFF
--- a/src/aclic.adoc
+++ b/src/aclic.adoc
@@ -190,7 +190,7 @@ The table below provides a summary of the ACLIC extensions.
 | Sscsps       | Conditional stack pointer swap at Supervisor level
 | Smnip        | Horizontal Nested Interrupt Preemption support at Machine level
 | Ssnip        | Horizontal Nested Interrupt Preemption support at Supervisor level
-| Smip         | Support for interrupt handler push/pop
+| Smihpp       | Support for interrupt handler push/pop
 |===
 
 As this specification aims for single-hart systems, no support for the H extension is foreseen.
@@ -207,7 +207,7 @@ Each row contains the dependencies of the extension named in the first column.
 | Ssivt          |    | x  |          |          |        |  
 | Smcsps         | x  |    |          |          |        |  
 | Sscsps         |    | x  |          |          |        |  
-| Smip           | (x)| (x)|          |          |        |  
+| Smihpp         | (x)| (x)|          |          |        |  
 | Smaiae         | x  | (x)| x        | (x)      |        |  
 | Smaclic        |    |    |          |          | x      |  
 | Ssaclic        |    |    |          |          | x      |  
@@ -429,6 +429,7 @@ and the conditions for a virtual instruction exception apply,
 in which case a virtual instruction exception is raised
 when in VS or VU mode instead of an illegal instruction exception.
 
+[[smcsps, Smcsps]]
 == Conditional Stack Pointer Swap extension (Smcsps, Sscsps)
 
 The Sscsps depends on the Smcsps extension and adds the ability for conditional stack pointer swap at supervisor level and below.
@@ -618,7 +619,7 @@ Included in: <<smcsps>>
 
 <<<
 
-[[smip, Smip]]
+[[smnip, Smnip]]
 
 == Horizontal Nested Interrupt Preemption Support (Smnip & Ssip)
 
@@ -943,7 +944,8 @@ The summarized behavior is the following:
  10       Reserved
 ----
 
-== Interrupt handler push and pop extension (Smip)
+[[smihpp, Smihpp]]
+== Interrupt handler push and pop extension (Smihpp)
 
 The interrupt handler push and pop extension adds instructions to accelerate interrupt handling, which additionally reduce code size.
 Interrupt handler latency and jitter is reduced by allowing the context save to happen speculatively in parallel to the vector table and handler fetch.
@@ -1000,9 +1002,9 @@ Interrupts shall not be enabled before completing the context save/restore opera
 Interrupts must be disabled before starting to restore context in the ipopxret instruction.
 As interrupts are disabled during the sequence as a side effect of the trap being taken, intermediate states during the execution of the instruction are not observable.
 +
-If the Smip extension is implemented, the first and last instructions of a interrupt handler must be a ipush and the last a ipopxret instruction, respectively.
+If the Smihpp extension is implemented, the first and last instructions of a interrupt handler must be a ipush and the last a ipopxret instruction, respectively.
 +
-NOTE: In contrast to the Zcmp push/pop instructions, Smip instructions do not encode an incremental stack pointer adjustment in order to ease late preemption and tail chaining.
+NOTE: In contrast to the Zcmp push/pop instructions, Smihpp instructions do not encode an incremental stack pointer adjustment in order to ease late preemption and tail chaining.
 +
 With these requirements, implementations are allowed to speculatively start executing an ipush instruction in case of a taken interrupt.
 
@@ -1164,7 +1166,7 @@ While this assembly sequence clobbers a4 and a5 to save CSRs,
 this is not a requirement. 
 SW shall not make assumptions about value of registers, with the exception of the a0-a3 as described earlier.
 
-Included in: <<smip>>
+Included in: <<smihpp>>
 
 <<<
 
@@ -1221,4 +1223,4 @@ where
   lr is lr on RV32 and ld on RV64
 ----
 
-Included in: <<smip>>
+Included in: <<smihpp>>

--- a/src/aclic.adoc
+++ b/src/aclic.adoc
@@ -190,7 +190,7 @@ The table below provides a summary of the ACLIC extensions.
 | Sscsps       | Conditional stack pointer swap at Supervisor level
 | Smnip        | Horizontal Nested Interrupt Preemption support at Machine level
 | Ssnip        | Horizontal Nested Interrupt Preemption support at Supervisor level
-| Smtp         | Support for trap handler push/pop
+| Smip         | Support for interrupt handler push/pop
 |===
 
 As this specification aims for single-hart systems, no support for the H extension is foreseen.
@@ -207,7 +207,7 @@ Each row contains the dependencies of the extension named in the first column.
 | Ssivt          |    | x  |          |          |        |  
 | Smcsps         | x  |    |          |          |        |  
 | Sscsps         |    | x  |          |          |        |  
-| Smtp           | (x)| (x)|          |          |        |  
+| Smip           | (x)| (x)|          |          |        |  
 | Smaiae         | x  | (x)| x        | (x)      |        |  
 | Smaclic        |    |    |          |          | x      |  
 | Ssaclic        |    |    |          |          | x      |  
@@ -618,7 +618,7 @@ Included in: <<smcsps>>
 
 <<<
 
-[[smtp, Smtp]]
+[[smip, Smip]]
 
 == Horizontal Nested Interrupt Preemption Support (Smnip & Ssip)
 
@@ -943,23 +943,25 @@ The summarized behavior is the following:
  10       Reserved
 ----
 
-== Trap handler push and pop extension (Smtp)
+== Interrupt handler push and pop extension (Smip)
 
-The trap handler push and pop extension adds instructions to accelerate trap handling, which additionally reduce code size.
-Trap handler latency and jitter is reduced by allowing the context save to happen speculatively in parallel to the vector table and handler fetch.
+The interrupt handler push and pop extension adds instructions to accelerate interrupt handling, which additionally reduce code size.
+Interrupt handler latency and jitter is reduced by allowing the context save to happen speculatively in parallel to the vector table and handler fetch.
 Additional latency reduction is achieved by allowing late-preemption of the push sequence in favor of a higher priority interrupt or synchronous exception.
-Trap handling throughput is increased by allowing tail-chaing of interrupts or synchronous exceptions, skipping the context restore and save in between servicing two handlers.
-The instructions are designed to be applicable to all RISC-V trap handling schemes.
+Interrupt handling throughput is increased by allowing tail-chaing of interrupts or synchronous exceptions, skipping the context restore and save in between servicing two handlers.
+The instructions are designed to be applicable to all RISC-V vectored interrupt handling schemes.
 
-=== Trap handler push and pop functional overview
+NOTE: In this scheme, handlers of interrupts and synchronous exceptions need to be strictly separated.
 
-. The tpush instruction
+=== Interrupt handler push and pop functional overview
+
+. The ipush instruction
   * Conditionally performs a stack pointer swap by executing cspspush sp
   * Saves hart's state of the preempted context that can be overwritten in case of a nested preemption
   * Save registers x10-x15 (these are the caller saved registers available in RVC)
   * Adjusts the stack pointer to create the stack frame
   * Clear the ip bit if writable
-  * Write trap information to argument registers
+  * Write interrupt identity to a0 register
   * Optionally, enable interrupts and clear the xstatus.XDT flag if the double trap extension is implemented at the current privilege level
 +
 NOTE: If a trap occurs during the sequence, then any operations which were executed before the trap may update architectural state and/or memory contents.
@@ -967,23 +969,10 @@ The preempting trap is expected to fully save and restore the architectural stat
 If the trap occurs before updating the stack pointer, it needs to be assumed that the stacked context was overwritten.
 In this case, if the instruction is resumed, any store operations must be re-executed.
 +
-The tpush instruction writes the value of the xcause CSR into register a0.
+The ipush instruction writes interrupt identity into register a0.
+In case of an external interrupt, this is the minor interrupt identity, else the major interrupt identity.
 This is beneficial also with vectored interrupts, as it allows sharing the same handler for similar interrupt sources.
 For example, if a peripheral exists multiple times in a system at different offsets, this can be handled with one handler.
-+
-The following table summarizes the written trap information:
-+
-[%autowidth]
-|===
-| Register | Synchronous Exception | Major Interrupt | External Interrupt (Interrupt Vector Table Mode)
-| a0 | `xcause` (equal to `xcause.Exception Code`) | Major Identity | Minor Identity
-| a1 | `xtval` | No Write | No Write
-| a2 | `xtval2` | No Write | No Write
-| a3 | `xtinst` | No Write | No Write
-|===
-+
-Software shall only use the information from the argument registers, as the corresponding CSRs may be overwritten by preempting traps.
-The values of xtval, xtval2, and xinst only need to be written to an argument register if the corresponding exception cause a write to the respective CSR.
 +
 As a consequence, the following prototype could serve for an interrupt handler at machine level.
 +
@@ -994,7 +983,7 @@ void interrupt_handler(uint16_t id) __attribute__((interrupt, prestacked("x10-x1
 
 It is explicitly allowed for the push instruction to clobber any of the saved GPRs.
 
-. Second The tpopxret instruction
+. Second The ipopxret instruction
   * Disables interrupts
   * Set the xstatus.XDT flag if the double trap extension is implemented at the current privilege level
   * Restores registers x10-x15
@@ -1007,32 +996,32 @@ NOTE: If a trap occurs during the sequence, then any operations which were execu
 A trap may not occur after updating the stack pointer, if the context was not yet fully restored from the stack.
 +
 There is no specific order mandated for the context save/restore, and the individual parts may occur in parallel.
-Interrupts shall not be enabled before completing the context save/restore operations of the tpush instruction.
-Interrupts must be disabled before starting to restore context in the tpopxret instruction.
+Interrupts shall not be enabled before completing the context save/restore operations of the ipush instruction.
+Interrupts must be disabled before starting to restore context in the ipopxret instruction.
 As interrupts are disabled during the sequence as a side effect of the trap being taken, intermediate states during the execution of the instruction are not observable.
 +
-If the Smtp extension is implemented, the first and last instructions of a trap handler must be a tpush and the last a tpopxret instruction, respectively.
+If the Smip extension is implemented, the first and last instructions of a interrupt handler must be a ipush and the last a ipopxret instruction, respectively.
 +
-NOTE: In contrast to the Zcmp push/pop instructions, Smtp instructions do not encode an incremental stack pointer adjustment in order to ease late preemption and tail chaining.
+NOTE: In contrast to the Zcmp push/pop instructions, Smip instructions do not encode an incremental stack pointer adjustment in order to ease late preemption and tail chaining.
 +
-With these requirements, implementations are allowed to speculatively start executing an tpush instruction in case of a taken interrupt.
+With these requirements, implementations are allowed to speculatively start executing an ipush instruction in case of a taken interrupt.
 
 === Late Preemption of the interrupt handler
 
-While executing the tpush instruction, a hart may optionally check for higher priority pending and enabled interrupts at the current privilege mode, and switch to fetching this trap handler instead.
+While executing the ipush instruction, a hart may optionally check for higher priority pending and enabled interrupts at the current privilege mode, and switch to fetching this interrupt handler instead.
 Once the instruction retires, or the interrupts are disabled, no late preemption can occur.
 
 === Tail chaining of interrupts handlers
 
-While executing the tpopxret instruction, a hart may optionally check for any pending and enabled interrupts at the current privilege mode.
-If such an interrupt exists, the hart may abort executing the tpopxret instruction and trigger the following actions:
+While executing the ipopxret instruction, a hart may optionally check for any pending and enabled interrupts at the current privilege mode.
+If such an interrupt exists, the hart may abort executing the ipopxret instruction and trigger the following actions:
   - Update the `xcause.Exception Code` to the corresponding interrupt id.
-  - Perform the trap handler fetch.
-  - Start executing the trap handler, while skipping the portions of tpush that have not been reverted by the aborted tpopxret.
+  - Perform the interrupt handler fetch.
+  - Start executing the interrupt handler, while skipping the portions of ipush that have not been reverted by the aborted ipopxret.
 
 Explicitly, {xepc}, {xpistatus} remain unchanged.
 
-NOTE: In the typical case of tail chaining, the check for another pending enabled interrupt is done after disabling interrupts at the start of the tpopxret instruction. In this case, only the conditional interrupt enablement of the tpush instruction would need to executed.
+NOTE: In the typical case of tail chaining, the check for another pending enabled interrupt is done after disabling interrupts at the start of the ipopxret instruction. In this case, only the conditional interrupt enablement of the ipush instruction would need to executed.
 
 Once the instruction retires, or the interrupts are disabled, no late preemption can occur.
 
@@ -1091,24 +1080,24 @@ stack pointer adjustment: 64
 
 Unless it can be guaranteed by design that faults causing synchronous exceptions cannot occur during the critical section,
 handling can only be resumed if the double trap extension is supported.
-The critical sections are defined as the time during execution of the tpush and tpopxret instruction, during which interrupts are disabled.
+The critical sections are defined as the time during execution of the ipush and ipopxret instruction, during which interrupts are disabled.
 
 === Debug
 
-As the execution of tpush may start before the instruction is fetched, breakpoint conditions met might observe an inconsistent state.
-Therefore, if a breakpoint is triggered because of an tpush instruction, the breakpoint shall be handled as if it occurred on the subsequent instruction.
+As the execution of ipush may start before the instruction is fetched, breakpoint conditions met might observe an inconsistent state.
+Therefore, if a breakpoint is triggered because of an ipush instruction, the breakpoint shall be handled as if it occurred on the subsequent instruction.
 
 <<<
 
 === Instructions
 
-==== tpush
+==== ipush
 
 Synopsis::
-Push trap context
+Push interrupt context
 
 Mnemonic::
-tpush preempt
+ipush preempt
 
 Encoding::
 [wavedrom, ,svg]
@@ -1125,7 +1114,7 @@ Encoding::
 ....
 
 Description::
-Saves the interrupted context at the beginning of a trap.
+Saves the interrupted context at the beginning of an interrupt.
 If preempt is '1', interrupts will be enabled at the end of the sequence.
 
 Behavior::
@@ -1146,12 +1135,10 @@ push:
   sr a4, OFFSET(sp)         # Save a4
   sr a5, OFFSET(sp)         # Save a5
   sr a6, OFFSET(sp)         # Save a6
-  csrr a0, xcause           # Get xcause of interrupted context to determine if exception
   csrr a4, xepc             # Get xepc of interrupt context
   csrr a5, xpistatus        # Get xpistatus of interrupt context
   sr a4, OFFSET(sp)         # Save xepc
   sr a5, OFFSET(sp)         # Save xpistatus
-  bgez a0, handle_exc       # Handle synchronous exception
   csrr a0, xtopi            # Read major interrupt number into a0
   li a1, xEI                # Write major identity of external interrupt to a1
   beq a0, a1, handle_ei     # Handle external interrupt
@@ -1161,15 +1148,10 @@ shift_idenity:
 finish_push:
   csrrsi zero, xstatus, XIE # Enable interrupts
 
+
 handle_ei:
   csrr a0, xtopei           # Read minor interrupt number into a0
   j shift_identity           # Jump back to rest of push sequence
-
-handle_exc:
-  csrr a1, xtval            # Get xcause of interrupted context
-  csrr a2, xtval2           # Get xepc of interrupt context
-  csrr a3, xtinst           # Get xpistatus of interrupt context
-  j finish_push             # Jump back to rest of push sequence
 
 where
   sr is sw on RV32 and sd on RV64
@@ -1182,17 +1164,17 @@ While this assembly sequence clobbers a4 and a5 to save CSRs,
 this is not a requirement. 
 SW shall not make assumptions about value of registers, with the exception of the a0-a3 as described earlier.
 
-Included in: <<smtp>>
+Included in: <<smip>>
 
 <<<
 
-==== tpopxret
+==== ipopxret
 
 Synopsis::
-Pop trap context
+Pop interrupt context
 
 Mnemonic::
-tpopxret
+ipopxret
 
 Encoding::
 [wavedrom, ,svg]
@@ -1208,7 +1190,7 @@ Encoding::
 ....
 
 Description::
-Restores an interrupted context at the end of a trap.
+Restores an interrupted context at the end of an interrupt.
 
 Behavior::
 
@@ -1239,4 +1221,4 @@ where
   lr is lr on RV32 and ld on RV64
 ----
 
-Included in: <<smtp>>
+Included in: <<smip>>


### PR DESCRIPTION
Exception handler are too different in nature to be handled with the same instruction. Combining both leads to too high complexity.
The benefits of ipush/ipop are only needed for interrupts