### PR TITLE
Fix: Remove misleading statement regarding H-extension scope

### DIFF
--- a/src/aclic.adoc
+++ b/src/aclic.adoc
@@ -197,7 +197,6 @@ The table below provides a summary of the ACLIC extensions.
 |===
 
 As this specification aims for single-hart systems, no support for the H extension is foreseen.
-Future specifications could extend the scope of these extensions to also be applicable to systems with the H extension.
 
 NOTE: The extensions defined here are orthogonal to the NMI and RNMI
 mechanisms. Their behavior is unchanged by the extensions of ACLIC.


### PR DESCRIPTION
Removes the statement: "Future specifications could extend the scope of these extensions to also be applicable to systems with the H extension."

As discussed in Issue #731, this statement implies a future path for H-extension support that is architecturally impractical for single-hart designs. Removing it prevents misleading implementers.

Ref: Discussion with @reosdev and @evgeniy-paltsev.
Fixes #731