### PR TITLE
Update GitHub Actions to requested versions

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -62,7 +62,7 @@ jobs:
 
       # Upload the built PDF files as a single artifact
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Build Artifacts
           path: ${{ github.workspace }}/build/*.pdf

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
This updates GitHub Actions workflow references to the requested versions.

Targets:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `softprops/action-gh-release` -> `v2`
