### PR TITLE
Smijt: Adjusting per-entry offset for RV64

### DIFF
--- a/src/aclic.adoc
+++ b/src/aclic.adoc
@@ -1458,7 +1458,7 @@ The PC upon interrupt is changed as follows:
 where:
 
   M[a]   = Contents of memory address at address "a"
-  entry = M[JTBASE+(vtoffset << (xijt.SHAMT + 2))]
+  entry = M[JTBASE + (vtoffset << (xijt.SHAMT + log2(XLEN/8)))]
   VEN    = entry & 0x1  # Vectoring enable
   JTMASK = ~0x1 if IALIGN=16 or ~0x3 if IALIGN=32  # Jump table mask
   JTBASE = xijt[XLEN-1:6]<<6  # IJT base is at least 64-byte aligned


### PR DESCRIPTION
This ensures RV64 entries cannot overlap.
RV32 behavior is unchanged